### PR TITLE
add mininet performance warning and fix the quque depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ This repository provides a Mininet environment to demonstrate an eBPF-based emul
 
 __REMARK__: The use of Mininet here is only for conveniently testing out the emulation method over two virtual hosts on a local host. The method does not need any mechanism from Mininet. The eBPF-based emulation method can (and is supposed to) be deployed to real-life nodes of a physical network. Please see the commands of the Mininet scripts for the deployment details.
 
+__WARNING - Performance Limitations in Virtual Environment__: Users should be aware that the performance characteristics observed in this Mininet-based virtual environment may significantly differ from those in physical network deployments. The virtual environment introduces several performance overhead factors:
+
+- **Virtual Interface Overhead**: Mininet uses veth (virtual Ethernet) pairs which require additional memory copying and packet processing compared to physical network interface.
+-  **Kernel Network Stack**: Unlike physical deployments where XDP can bypass most of the kernel network stack, virtual interfaces must traverse the complete Linux networking stack, introducing additional latency and CPU overhead.
+-  **Memory Copy Operations**: Each packet traversing veth interfaces requires multiple memory copy operations that are noet present in physical network cards with DMA capabilities.
+
 # The Mininet environment for eBPF-based Starlink emulation
 
 Please ensure that the host of Mininet runs a Linux kernel version supporting eBPF features. Linux 5.11 or higher is recommended. The following procedures are tested on Ubuntu 22.04 with Linux 5.15.0-23-generic. The environment consists of two hosts as follows, where the uplink (h1->h2) and downlink propagation delays are emulated on `h1` and `h2` using `edt_delay_packet.o`, respectively, and the corresponding losses are emulated on `h2` and `h1` using `xdp_drop_packet.o`, repsectively. 

--- a/ebpf-emu-in-mn/mininet-2hop-emulate.py
+++ b/ebpf-emu-in-mn/mininet-2hop-emulate.py
@@ -37,7 +37,10 @@ def deploy_ebpf():
     h1.cmd('sudo clang -O2 -g -target bpf -c edt_delay_packet.c -o edt_delay_packet.o')
     h1.cmd('sudo tc qdisc add dev h1-eth0 clsact')
     h1.cmd('sudo tc filter add dev h1-eth0 egress bpf direct-action obj edt_delay_packet.o sec delay_ebpf')
-    h1.cmd('sudo tc qdisc add dev h1-eth0 root fq')
+    h1.cmd('sudo tc qdisc add dev h1-eth0 root handle 1: htb default 10 r2q 1')
+    h1.cmd('sudo tc class add dev h1-eth0 parent 1: classid 1:1 htb rate 60mbit ceil 60mbit quantum 10000 ')
+    h1.cmd('sudo tc qdisc add dev h1-eth0 parent 1:1 handle 10: fq flow_limit 5000')
+    h1.cmd('sudo tc filter add dev h1-eth0 parent 1: protocol ip u32 match u32 0 0 flowid 1:1') 
  
     #h1.cmd('mount -t bpf bpf /sys/fs/bpf/')
     h1.cmd('sudo clang -O2 -g -target bpf -c xdp_drop_packet.c -o xdp_drop_packet.o')
@@ -50,7 +53,10 @@ def deploy_ebpf():
     h2.cmd('sudo clang -O2 -g -target bpf -c edt_delay_packet.c -o edt_delay_packet.o')
     h2.cmd('sudo tc qdisc add dev h2-eth0 clsact')
     h2.cmd('sudo tc filter add dev h2-eth0 egress bpf direct-action obj edt_delay_packet.o sec delay_ebpf')
-    h2.cmd('sudo tc qdisc add dev h2-eth0 root fq')
+    h2.cmd('sudo tc qdisc add dev h2-eth0 root handle 1: htb default 10 r2q 1')
+    h2.cmd('sudo tc class add dev h2-eth0 parent 1: classid 1:1 htb rate 60mbit ceil 60mbit quantum 10000')
+    h2.cmd('sudo tc qdisc add dev h2-eth0 parent 1:1 handle 10: fq flow_limit 5000')
+    h2.cmd('sudo tc filter add dev h2-eth0 parent 1: protocol ip u32 match u32 0 0 flowid 1:1') 
  
 
     #h2.cmd('mount -t bpf bpf /sys/fs/bpf/')


### PR DESCRIPTION
### Queue Depth Problem
The default Linux FQ scheduler `flow_limit=100` packets is insufficient for:
- High-bandwidth applications generating packet bursts
- Delay emulation scenarios requiring timing control buffering  
- Virtual interface latency variations causing temporary buildups

### Virtual vs Physical Interface Differences
- **veth pairs** lack hardware buffering capabilities present in physical NICs
- **Irregular processing timing** requires larger software queues to prevent drops
- **eBPF delay emulation** needs sufficient queue space for scheduled packet transmissions
