### PR TITLE
Avoid the problem of incompatible kernel header file versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please ensure that the host of Mininet runs a Linux kernel version supporting eB
 ## Step 1: Install necessary tools for eBPF
 ```bash
 sudo apt update && sudo apt upgrade
-sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r)
+sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r) libbpf-dev
 ```
 
 ## Step 2: Prepare trace files from irtt measurement data

--- a/ebpf-emu-in-mn/mininet-2hop-emulate.py
+++ b/ebpf-emu-in-mn/mininet-2hop-emulate.py
@@ -34,7 +34,9 @@ def deploy_ebpf():
     # Attach eBPF program to interface of the first host
     h1.cmd('cd h1/')
     h1.cmd('sudo mount -t bpf bpf /sys/fs/bpf/')
-    h1.cmd('sudo clang -O2 -g -target bpf -c edt_delay_packet.c -o edt_delay_packet.o')
+    h1.cmd('sudo clang -O2 -g -target bpf \
+           -I /usr/include/$(uname -m)-linux-gnu \
+           -c edt_delay_packet.c -o edt_delay_packet.o')
     h1.cmd('sudo tc qdisc add dev h1-eth0 clsact')
     h1.cmd('sudo tc filter add dev h1-eth0 egress bpf direct-action obj edt_delay_packet.o sec delay_ebpf')
     h1.cmd('sudo tc qdisc add dev h1-eth0 root handle 1: htb default 10 r2q 1')
@@ -43,14 +45,18 @@ def deploy_ebpf():
     h1.cmd('sudo tc filter add dev h1-eth0 parent 1: protocol ip u32 match u32 0 0 flowid 1:1') 
  
     #h1.cmd('mount -t bpf bpf /sys/fs/bpf/')
-    h1.cmd('sudo clang -O2 -g -target bpf -c xdp_drop_packet.c -o xdp_drop_packet.o')
+    h1.cmd('sudo clang -O2 -g -target bpf \
+           -I /usr/include/$(uname -m)-linux-gnu \
+           -c xdp_drop_packet.c -o xdp_drop_packet.o')
     h1.cmd('sudo ip link set dev h1-eth0 xdpgeneric obj xdp_drop_packet.o sec xdp_port_filter')
 
 
     # Attach eBPF program to interface of the second host
     h2.cmd('cd h2/')
     h2.cmd('sudo mount -t bpf bpf /sys/fs/bpf/')
-    h2.cmd('sudo clang -O2 -g -target bpf -c edt_delay_packet.c -o edt_delay_packet.o')
+    h2.cmd('sudo clang -O2 -g -target bpf \
+           -I /usr/include/$(uname -m)-linux-gnu \
+           -c edt_delay_packet.c -o edt_delay_packet.o')
     h2.cmd('sudo tc qdisc add dev h2-eth0 clsact')
     h2.cmd('sudo tc filter add dev h2-eth0 egress bpf direct-action obj edt_delay_packet.o sec delay_ebpf')
     h2.cmd('sudo tc qdisc add dev h2-eth0 root handle 1: htb default 10 r2q 1')
@@ -60,7 +66,9 @@ def deploy_ebpf():
  
 
     #h2.cmd('mount -t bpf bpf /sys/fs/bpf/')
-    h2.cmd('sudo clang -O2 -g -target bpf -c xdp_drop_packet.c -o xdp_drop_packet.o')
+    h2.cmd('sudo clang -O2 -g -target bpf \
+           -I /usr/include/$(uname -m)-linux-gnu \
+           -c xdp_drop_packet.c -o xdp_drop_packet.o')
     h2.cmd('sudo ip link set dev h2-eth0 xdpgeneric obj xdp_drop_packet.o sec xdp_port_filter')
 
     


### PR DESCRIPTION
update README.md
audo apt install libbpf-dev 
update mininet-2hop-emulate.py
-I /usr/include/$(name -m)-linux-gnu
It uses distribution-curated headers specifically designed for userspace development, avoiding kernel build system complexities and incompatible kernel header file versions.