### PR TITLE
feat: add time-driven replay mode for high-fidelity tcp emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ sudo python3 update_map_value.py --keyword loss_map_2 --file_path /YOUR_PATH_TO/
 
 **The map updating takes time.** For example, updating 10000 data points may take a few seconds.
 
+## Step 5: (Optional) Switch Emulation Mode for TCP testing
+
+By default, the eBPF programs run in **Packet-Driven Mode (Mode 0)**, where the trace index advances by 1 for every packet received. This is suitable for Constant Bit Rate (CBR) traffic like `irtt`. 
+
+However, if you want to test Variable Bit Rate (VBR) traffic or TCP throughput (e.g., using `iperf3`), the bursty nature of TCP will consume the trace too quickly. For such tests, you should switch to **Time-Driven Mode (Mode 1)**, where the trace index advances strictly based on the physical clock (`bpf_ktime_get_ns()`).
+
+To switch the mode, run the following script in the `ebpf-emu-in-mn` directory:
+
+```bash
+# Switch to Time-Driven Mode (for TCP / iperf3)
+sudo python3 set_mode.py --mode 1
+
+# Switch back to Packet-Driven Mode (for irtt)
+sudo python3 set_mode.py --mode 0
+```
 
 # Test the emulated link
 After the emulation environment is configured, you may run `irtt` in Mininet to verify the emulated link. In `h2`'s xterm, run

--- a/ebpf-emu-in-mn/h1/edt_delay_packet.c
+++ b/ebpf-emu-in-mn/h1/edt_delay_packet.c
@@ -5,7 +5,7 @@
 #include <linux/ip.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
-#include <linux/in.h> // For IPPROTO_TCP and IPPROTO_UDP
+#include <linux/in.h>
 
 #define bpf_htons(x)   __builtin_bswap16(x)
 #define bpf_ntohs(x)   __builtin_bswap16(x)
@@ -14,6 +14,17 @@
 #define FILTER_PORT_2 2112
 
 #define TRACE_LEN 10000
+#define TRACE_INTERVAL_NS 10000000ULL // 10ms
+
+#define MODE_PACKET_DRIVEN 0
+#define MODE_TIME_DRIVEN   1
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} config_map SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -23,74 +34,68 @@ struct {
 } delay_map_1 SEC(".maps");
 
 static __u32 packet_index = 0;
+static __u64 start_time = 0;
 
 SEC("delay_ebpf")
 int edt_delay_packet(struct __sk_buff *skb) {
     void *data = (void *)(long)skb->data;
     void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = data; //Ethernet header
+    struct ethhdr *eth = data;
     __u64 nh_off = sizeof(struct ethhdr);
-    __u32 key = packet_index % TRACE_LEN;
 
     if (data + nh_off > data_end) {
         return TC_ACT_OK;
     }
 
-    // only ipv4 packets are processed
     if (eth->h_proto == bpf_htons(ETH_P_IP)) {
-        struct iphdr *ip = data + nh_off;   // get the ip header
-        nh_off += sizeof(*ip);      // update the offset
+        struct iphdr *ip = data + nh_off;
+        nh_off += sizeof(*ip);
         if ((void*)ip + sizeof(*ip) > data_end) {
             return TC_ACT_OK;
         }
 
-        // get the ports for the trasport layer protocol (tcp and udp)
         if (ip->protocol == IPPROTO_TCP || ip->protocol == IPPROTO_UDP) {
-            __u16 *ports = NULL;
-
-                ports = data + nh_off;
-
-
+            __u16 *ports = data + nh_off;
             if ((void*)ports + sizeof(__u16) * 2 > data_end) {
                 return TC_ACT_OK;
             }
-            //bpf_ntohs Network to Host Short 
+
             __u16 src_port = bpf_ntohs(ports[0]);
             __u16 dst_port = bpf_ntohs(ports[1]);
 
-            // print port information
-            //bpf_printk("IP protocol: %u, Src Port: %u, Dst Port: %u\n", 
-            //           ip->protocol, src_port, dst_port);
-
-            // only packets whose source or destination port is FILTER_PORT_1 or FILTER_PORT_2 are processed
             if (src_port == FILTER_PORT_1 || src_port == FILTER_PORT_2 ||
                 dst_port == FILTER_PORT_1 || dst_port == FILTER_PORT_2) {
-                __u32 key = packet_index % TRACE_LEN;
-                __u32 *delay_ns;
+                
+                __u32 config_key = 0;
+                __u32 *mode_ptr = bpf_map_lookup_elem(&config_map, &config_key);
+                __u32 current_mode = mode_ptr ? *mode_ptr : MODE_PACKET_DRIVEN;
 
-                delay_ns = bpf_map_lookup_elem(&delay_map_1, &key);
+                __u32 trace_key = 0;
+                __u64 now = bpf_ktime_get_ns();
+
+                if (current_mode == MODE_TIME_DRIVEN) {
+                    if (start_time == 0) {
+                        start_time = now;
+                    }
+                    __u64 elapsed = now - start_time;
+                    trace_key = (elapsed / TRACE_INTERVAL_NS) % TRACE_LEN;
+                } else {
+                    trace_key = packet_index % TRACE_LEN;
+                }
+
+                __u32 *delay_ns = bpf_map_lookup_elem(&delay_map_1, &trace_key);
                 if (delay_ns) {
-                    //bpf_printk("Delaying packet by %u ns\n", *delay_ns);
-
-                    // get the current nanosecond timestamp
-                    __u64 now = bpf_ktime_get_ns();
-
-                    // set the departure : time current time + delay time
                     skb->tstamp = now + ((__u64) * delay_ns);
 
-                    //update the packet_index 
-                    packet_index++;
-                    if (packet_index >= TRACE_LEN) {
-                        packet_index = 0;
+                    if (current_mode == MODE_PACKET_DRIVEN) {
+                        packet_index++;
+                        if (packet_index >= TRACE_LEN) {
+                            packet_index = 0;
+                        }
                     }
-
-                } else {
-                    //bpf_printk("Delay not found in map\n");
                 }
             }
         }
-    } else {
-        //bpf_printk("Not an IPv4 packet\n");
     }
 
     return TC_ACT_OK;

--- a/ebpf-emu-in-mn/h1/xdp_drop_packet.c
+++ b/ebpf-emu-in-mn/h1/xdp_drop_packet.c
@@ -13,6 +13,17 @@
 #define FILTER_PORT_2 2112 
 
 #define TRACE_LEN 10000
+#define TRACE_INTERVAL_NS 10000000ULL // 10ms
+
+#define MODE_PACKET_DRIVEN 0
+#define MODE_TIME_DRIVEN   1
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} config_map SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -22,6 +33,7 @@ struct {
 } loss_map_1 SEC(".maps");
 
 static __u32 packet_index = 0;
+static __u64 start_time = 0;
 
 SEC("xdp_port_filter")
 int xdp_drop_packet(struct xdp_md *ctx) {
@@ -38,7 +50,6 @@ int xdp_drop_packet(struct xdp_md *ctx) {
         return XDP_PASS;
     }
 
-    // only ipv4 packets are processed
     if (iph->protocol != IPPROTO_TCP && iph->protocol != IPPROTO_UDP) {
         return XDP_PASS;
     }
@@ -47,41 +58,51 @@ int xdp_drop_packet(struct xdp_md *ctx) {
     __u16 sport = 0, dport = 0;
     __u16 *ports;
 
-    // extract the source and destination ports
     if (iph->protocol == IPPROTO_TCP || iph->protocol == IPPROTO_UDP) {
         ports = data + offset;
 
-        // check if the packet is complete
         if ((void *)(ports + 2) > data_end) {
             return XDP_PASS;
         }
 
-        // bpf_ntohs Network to Host Short 
         sport = bpf_ntohs(ports[0]);
         dport = bpf_ntohs(ports[1]);
     }
 
-    // Checks if the port matches the filtering criteria
     if (sport == FILTER_PORT_1 || sport == FILTER_PORT_2 || dport == FILTER_PORT_1 || dport == FILTER_PORT_2) {
-        __u32 key = packet_index % TRACE_LEN;
-        int *trace_value = bpf_map_lookup_elem(&loss_map_1, &key);
+        
+        __u32 config_key = 0;
+        __u32 *mode_ptr = bpf_map_lookup_elem(&config_map, &config_key);
+        __u32 current_mode = mode_ptr ? *mode_ptr : MODE_PACKET_DRIVEN;
+
+        __u32 trace_key = 0;
+        __u64 now = bpf_ktime_get_ns();
+
+        if (current_mode == MODE_TIME_DRIVEN) {
+            if (start_time == 0) {
+                start_time = now;
+            }
+            __u64 elapsed = now - start_time;
+            trace_key = (elapsed / TRACE_INTERVAL_NS) % TRACE_LEN;
+        } else {
+            trace_key = packet_index % TRACE_LEN;
+        }
+
+        int *trace_value = bpf_map_lookup_elem(&loss_map_1, &trace_key);
 
         if (!trace_value) {
-            bpf_printk("Key %u not found\n", key);
             return XDP_PASS;
         }
 
-        //bpf_printk("Packet at index %u with key %u has trace_value %d\n", packet_index, key, *trace_value);
-
         if (*trace_value) {
-            //bpf_printk("Dropping %s Packet: Source Port: %u, Dest Port: %u\n",
-            //           (iph->protocol == IPPROTO_TCP) ? "TCP" : "UDP", sport, dport);
-            packet_index = (packet_index + 1) % TRACE_LEN;
+            if (current_mode == MODE_PACKET_DRIVEN) {
+                packet_index = (packet_index + 1) % TRACE_LEN;
+            }
             return XDP_DROP;
         } else {
-            //bpf_printk("Passing %s Packet: Source Port: %u, Dest Port: %u\n",
-            //          (iph->protocol == IPPROTO_TCP) ? "TCP" : "UDP", sport, dport);
-            packet_index = (packet_index + 1) % TRACE_LEN;
+            if (current_mode == MODE_PACKET_DRIVEN) {
+                packet_index = (packet_index + 1) % TRACE_LEN;
+            }
         }
     }
 

--- a/ebpf-emu-in-mn/h2/edt_delay_packet.c
+++ b/ebpf-emu-in-mn/h2/edt_delay_packet.c
@@ -5,7 +5,7 @@
 #include <linux/ip.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
-#include <linux/in.h> // For IPPROTO_TCP and IPPROTO_UDP
+#include <linux/in.h>
 
 #define bpf_htons(x)   __builtin_bswap16(x)
 #define bpf_ntohs(x)   __builtin_bswap16(x)
@@ -14,6 +14,17 @@
 #define FILTER_PORT_2 2112
 
 #define TRACE_LEN 10000
+#define TRACE_INTERVAL_NS 10000000ULL // 10ms
+
+#define MODE_PACKET_DRIVEN 0
+#define MODE_TIME_DRIVEN   1
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} config_map SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -23,74 +34,68 @@ struct {
 } delay_map_2 SEC(".maps");
 
 static __u32 packet_index = 0;
+static __u64 start_time = 0;
 
 SEC("delay_ebpf")
 int edt_delay_packet(struct __sk_buff *skb) {
     void *data = (void *)(long)skb->data;
     void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = data; //Ethernet header
+    struct ethhdr *eth = data;
     __u64 nh_off = sizeof(struct ethhdr);
-    __u32 key = packet_index % TRACE_LEN;
 
     if (data + nh_off > data_end) {
         return TC_ACT_OK;
     }
 
-    // only ipv4 packets are processed
     if (eth->h_proto == bpf_htons(ETH_P_IP)) {
-        struct iphdr *ip = data + nh_off;   // get the ip header
-        nh_off += sizeof(*ip);      // update the offset
+        struct iphdr *ip = data + nh_off;
+        nh_off += sizeof(*ip);
         if ((void*)ip + sizeof(*ip) > data_end) {
             return TC_ACT_OK;
         }
 
-        // get the ports for the trasport layer protocol (tcp and udp)
         if (ip->protocol == IPPROTO_TCP || ip->protocol == IPPROTO_UDP) {
-            __u16 *ports = NULL;
-
-                ports = data + nh_off;
-
-
+            __u16 *ports = data + nh_off;
             if ((void*)ports + sizeof(__u16) * 2 > data_end) {
                 return TC_ACT_OK;
             }
-            //bpf_ntohs Network to Host Short 
+
             __u16 src_port = bpf_ntohs(ports[0]);
             __u16 dst_port = bpf_ntohs(ports[1]);
 
-            // print port information
-            //bpf_printk("IP protocol: %u, Src Port: %u, Dst Port: %u\n", 
-            //           ip->protocol, src_port, dst_port);
-
-            // only packets whose source or destination port is FILTER_PORT_1 or FILTER_PORT_2 are processed
             if (src_port == FILTER_PORT_1 || src_port == FILTER_PORT_2 ||
                 dst_port == FILTER_PORT_1 || dst_port == FILTER_PORT_2) {
-                __u32 key = packet_index % TRACE_LEN;
-                __u32 *delay_ns;
+                
+                __u32 config_key = 0;
+                __u32 *mode_ptr = bpf_map_lookup_elem(&config_map, &config_key);
+                __u32 current_mode = mode_ptr ? *mode_ptr : MODE_PACKET_DRIVEN;
 
-                delay_ns = bpf_map_lookup_elem(&delay_map_2, &key);
+                __u32 trace_key = 0;
+                __u64 now = bpf_ktime_get_ns();
+
+                if (current_mode == MODE_TIME_DRIVEN) {
+                    if (start_time == 0) {
+                        start_time = now;
+                    }
+                    __u64 elapsed = now - start_time;
+                    trace_key = (elapsed / TRACE_INTERVAL_NS) % TRACE_LEN;
+                } else {
+                    trace_key = packet_index % TRACE_LEN;
+                }
+
+                __u32 *delay_ns = bpf_map_lookup_elem(&delay_map_2, &trace_key);
                 if (delay_ns) {
-                    //bpf_printk("Delaying packet by %u ns\n", *delay_ns);
-
-                    // get the current nanosecond timestamp
-                    __u64 now = bpf_ktime_get_ns();
-
-                    // set the departure : time current time + delay time
                     skb->tstamp = now + ((__u64) * delay_ns);
 
-                    //update the packet_index 
-                    packet_index++;
-                    if (packet_index >= TRACE_LEN) {
-                        packet_index = 0;
+                    if (current_mode == MODE_PACKET_DRIVEN) {
+                        packet_index++;
+                        if (packet_index >= TRACE_LEN) {
+                            packet_index = 0;
+                        }
                     }
-
-                } else {
-                    //bpf_printk("Delay not found in map\n");
                 }
             }
         }
-    } else {
-        //bpf_printk("Not an IPv4 packet\n");
     }
 
     return TC_ACT_OK;

--- a/ebpf-emu-in-mn/h2/xdp_drop_packet.c
+++ b/ebpf-emu-in-mn/h2/xdp_drop_packet.c
@@ -13,6 +13,17 @@
 #define FILTER_PORT_2 2112 
 
 #define TRACE_LEN 10000
+#define TRACE_INTERVAL_NS 10000000ULL // 10ms
+
+#define MODE_PACKET_DRIVEN 0
+#define MODE_TIME_DRIVEN   1
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} config_map SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -22,6 +33,7 @@ struct {
 } loss_map_2 SEC(".maps");
 
 static __u32 packet_index = 0;
+static __u64 start_time = 0;
 
 SEC("xdp_port_filter")
 int xdp_drop_packet(struct xdp_md *ctx) {
@@ -38,7 +50,6 @@ int xdp_drop_packet(struct xdp_md *ctx) {
         return XDP_PASS;
     }
 
-    // only ipv4 packets are processed
     if (iph->protocol != IPPROTO_TCP && iph->protocol != IPPROTO_UDP) {
         return XDP_PASS;
     }
@@ -47,41 +58,51 @@ int xdp_drop_packet(struct xdp_md *ctx) {
     __u16 sport = 0, dport = 0;
     __u16 *ports;
 
-    // extract the source and destination ports
     if (iph->protocol == IPPROTO_TCP || iph->protocol == IPPROTO_UDP) {
         ports = data + offset;
 
-        // check if the packet is complete
         if ((void *)(ports + 2) > data_end) {
             return XDP_PASS;
         }
 
-        // bpf_ntohs Network to Host Short 
         sport = bpf_ntohs(ports[0]);
         dport = bpf_ntohs(ports[1]);
     }
 
-    // Checks if the port matches the filtering criteria
     if (sport == FILTER_PORT_1 || sport == FILTER_PORT_2 || dport == FILTER_PORT_1 || dport == FILTER_PORT_2) {
-        __u32 key = packet_index % TRACE_LEN;
-        int *trace_value = bpf_map_lookup_elem(&loss_map_2, &key);
+        
+        __u32 config_key = 0;
+        __u32 *mode_ptr = bpf_map_lookup_elem(&config_map, &config_key);
+        __u32 current_mode = mode_ptr ? *mode_ptr : MODE_PACKET_DRIVEN;
+
+        __u32 trace_key = 0;
+        __u64 now = bpf_ktime_get_ns();
+
+        if (current_mode == MODE_TIME_DRIVEN) {
+            if (start_time == 0) {
+                start_time = now;
+            }
+            __u64 elapsed = now - start_time;
+            trace_key = (elapsed / TRACE_INTERVAL_NS) % TRACE_LEN;
+        } else {
+            trace_key = packet_index % TRACE_LEN;
+        }
+
+        int *trace_value = bpf_map_lookup_elem(&loss_map_2, &trace_key);
 
         if (!trace_value) {
-            bpf_printk("Key %u not found\n", key);
             return XDP_PASS;
         }
 
-        //bpf_printk("Packet at index %u with key %u has trace_value %d\n", packet_index, key, *trace_value);
-
         if (*trace_value) {
-            //bpf_printk("Dropping %s Packet: Source Port: %u, Dest Port: %u\n",
-            //           (iph->protocol == IPPROTO_TCP) ? "TCP" : "UDP", sport, dport);
-            packet_index = (packet_index + 1) % TRACE_LEN;
+            if (current_mode == MODE_PACKET_DRIVEN) {
+                packet_index = (packet_index + 1) % TRACE_LEN;
+            }
             return XDP_DROP;
         } else {
-            //bpf_printk("Passing %s Packet: Source Port: %u, Dest Port: %u\n",
-            //          (iph->protocol == IPPROTO_TCP) ? "TCP" : "UDP", sport, dport);
-            packet_index = (packet_index + 1) % TRACE_LEN;
+            if (current_mode == MODE_PACKET_DRIVEN) {
+                packet_index = (packet_index + 1) % TRACE_LEN;
+            }
         }
     }
 

--- a/ebpf-emu-in-mn/set_mode.py
+++ b/ebpf-emu-in-mn/set_mode.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+bpf map config update script
+Used to switch between Packet-Driven (0) and Time-Driven (1) modes.
+'''
+import argparse
+import subprocess
+import ctypes
+import ctypes.util
+import os
+import sys
+
+# === Libbpf Setup ===
+libbpf_path = ctypes.util.find_library('bpf')
+if not libbpf_path:
+    possible_paths = [
+        '/usr/lib/x86_64-linux-gnu/libbpf.so', 
+        '/usr/lib64/libbpf.so', 
+        '/usr/lib/libbpf.so'
+    ]
+    for p in possible_paths:
+        if os.path.exists(p):
+            libbpf_path = p
+            break
+
+if not libbpf_path:
+    print("Error: libbpf.so not found. Please install libbpf-dev or ensure libbpf.so is in your library path.")
+    sys.exit(1)
+
+try:
+    libbpf = ctypes.CDLL(libbpf_path)
+    libbpf.bpf_map_get_fd_by_id.argtypes = [ctypes.c_uint32]
+    libbpf.bpf_map_get_fd_by_id.restype = ctypes.c_int
+    libbpf.bpf_map_update_elem.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint64]
+    libbpf.bpf_map_update_elem.restype = ctypes.c_int
+except Exception as e:
+    print(f"Error loading libbpf functions: {e}")
+    sys.exit(1)
+
+def get_map_ids(keyword):
+    """Get all map IDs matching the keyword"""
+    map_ids = []
+    try:
+        cmd = ['sudo', 'bpftool', 'map', 'show']
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        for line in result.stdout.splitlines():
+            if keyword in line:
+                parts = line.split()
+                map_id = parts[0][:-1]
+                map_ids.append(int(map_id))
+    except Exception as e:
+        print(f"Error finding map: {e}")
+    return map_ids
+
+def update_mode(map_id, mode):
+    """Update config_map with the selected mode"""
+    map_fd = libbpf.bpf_map_get_fd_by_id(map_id)
+    if map_fd < 0:
+        print(f"Failed to get FD for map ID {map_id}.")
+        return False
+
+    try:
+        c_key = ctypes.c_uint32(0)
+        c_value = ctypes.c_uint32(mode)
+        
+        ret = libbpf.bpf_map_update_elem(map_fd, ctypes.byref(c_key), ctypes.byref(c_value), 0)
+        if ret != 0:
+            err = ctypes.get_errno()
+            print(f"Failed to update map {map_id}: errno {err}")
+            return False
+        return True
+    finally:
+        os.close(map_fd)
+
+if __name__ == "__main__":
+    if os.geteuid() != 0:
+        print("Error: This script must be run as root (sudo).")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description='Set eBPF Emulation Mode.')
+    parser.add_argument('--mode', type=int, choices=[0, 1], required=True, 
+                        help='0 for Packet-Driven (irtt), 1 for Time-Driven (iperf3)')
+    
+    args = parser.parse_args()
+
+    # Find all config_map instances (should be 4: delay/loss for B and C)
+    map_ids = get_map_ids("config_map")
+    
+    if not map_ids:
+        print("No config_map found. Are the eBPF programs loaded?")
+        sys.exit(1)
+        
+    success_count = 0
+    for mid in map_ids:
+        if update_mode(mid, args.mode):
+            success_count += 1
+            
+    mode_str = "Time-Driven" if args.mode == 1 else "Packet-Driven"
+    print(f"Successfully updated {success_count}/{len(map_ids)} config_maps to {mode_str} Mode ({args.mode}).")


### PR DESCRIPTION
This PR introduces a Dual-Mode (Packet-Driven & Time Driven) mechanism to the eBPF programs, allowing the emulation environment to accurately evaluate bursty traffic like TCP. It also includes a Python script (set_mode.py) to dynamically switch between these mode via the eBPF control plane.

How does it work?
1. Control Plan Map: Added a `config_map` to the C programs to store the current running mode (0 for Packet-Driven, 1 for Time-Driven).
2. Time-Driven Logic: When Mode 1 is active, the trace index is no longer calculated by packet count. Instead, it is calculated based on the absolute physical time elapsed since the first packet arrived, using `bpf_ktime_get_ns()`.
```c
__u64 elapsed = now - start_time;
trace_key = (elapsed / TRACE_INTERVAL_NS) % TRACE_LEN; // TRACE_INTERVAL_NS is set to 10ms
```
3. Dynamic Switching: Added `set_mode.py` which uses `libbpf` to safely update the `config_map` on the fly without needing to reload the eBPF programs or testart Mininet.

Changes Included:
- ebpf-emu-in-mn/h1/edt_delay_packet.c & xdp_drop_packet.c: Added config_map and time-driven index calculation logic.
- ebpf-emu-in-mn/h2/edt_delay_packet.c & xdp_drop_packet.c: Added config_map and time-driven index calculation logic.
- ebpf-emu-in-mn/set_mode.py: Added the Python script to toggle modes.
- README.md: Added a new section explaining the two modes and providing instructions on how to use set_mode.py for TCP testing.